### PR TITLE
Fix the images to be smaller on mobile devices

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -107,6 +107,7 @@ li {
 
 img {
   max-width: 100%;
+  max-height: 100vh;
   height: auto;
 }
 


### PR DESCRIPTION
This commit makes the images shrink and fit the size of the window, while they used to be shown in their original size.